### PR TITLE
Feat improved group entries

### DIFF
--- a/src/components/ObsidianIcon.tsx
+++ b/src/components/ObsidianIcon.tsx
@@ -1,18 +1,18 @@
 import { setIcon } from "obsidian";
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, DOMAttributes } from "react";
 
 type Props = {
 	// Obsidian icon
 	icon: string;
 	// Class name to apply to the icon
 	className?: string;
-};
+} & DOMAttributes<HTMLDivElement>;
 
 /**
  * Wrapper around the Obsidian setIcon function to use
  * built-in lucide icons from Obsidian
  */
-export default function ObsidianIcon({ icon, className }: Props) {
+export default function ObsidianIcon({ icon, className, ...props }: Props) {
 	const wrapperRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
@@ -36,6 +36,7 @@ export default function ObsidianIcon({ icon, className }: Props) {
 
 	return (
 		<div
+			{...props}
 			style={{
 				display: "inline-block",
 				lineHeight: 1,

--- a/src/components/TimesheetRows.tsx
+++ b/src/components/TimesheetRows.tsx
@@ -6,7 +6,7 @@ import { getEntriesOrdered, getUniqueEntryHash } from "@/timekeep";
 
 type Props = {
 	// Collection of entries
-	entries: TimeEntry[] | null;
+	entries: TimeEntry[];
 	// Indentation for the entries
 	indent: number;
 };
@@ -19,17 +19,17 @@ export default function TimesheetRows({ entries, indent }: Props) {
 	const settings = useSettings();
 	// Memoized sub entries
 	const entriesOrdered = useMemo(
-		() => (entries ? getEntriesOrdered(entries, settings) : null),
+		() => getEntriesOrdered(entries, settings),
 		[entries, settings]
 	);
 
-	return (
-		entriesOrdered != null &&
-		entriesOrdered.map((entry) => (
-			<Fragment key={getUniqueEntryHash(entry)}>
-				<TimesheetRow entry={entry} indent={indent} />
+	return entriesOrdered.map((entry) => (
+		<Fragment key={getUniqueEntryHash(entry)}>
+			<TimesheetRow entry={entry} indent={indent} />
+
+			{entry.subEntries !== null && !entry.collapsed && (
 				<TimesheetRows entries={entry.subEntries} indent={indent + 1} />
-			</Fragment>
-		))
-	);
+			)}
+		</Fragment>
+	));
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -37,6 +37,8 @@ const TIME_ENTRY_GROUP_BASE = z.object({
 	name: z.string(),
 	startTime: z.null(),
 	endTime: z.null(),
+	// Optional field to indicate the entry is collapsed
+	collapsed: z.boolean().optional(),
 });
 
 // Schema for a time entry group

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,8 +2,7 @@
 	display: inline-block;
 	height: 1rem;
 	width: 0.2rem;
-	border-left: 0.1rem solid var(--color-base-40);
-	margin-right: 0.1rem;
+	border-left: 0.2rem solid var(--color-base-40);
 }
 
 .timekeep-container {
@@ -26,6 +25,10 @@
 
 .timekeep-row {
 	width: 100%;
+}
+
+.timekeep-row[data-sub-entires="true"] {
+	border-bottom: 2px solid var(--color-base-40);
 }
 
 .timesheet-editing {
@@ -95,7 +98,7 @@
 	gap: 0.5rem;
 	flex: auto;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-end;
 	width: 100%;
 	height: 100%;
 }
@@ -204,4 +207,10 @@
 
 .timekeep-error {
 	padding: 2rem;
+}
+
+.timekeep-collapse-icon {
+	margin-left: 0.5rem;
+	cursor: pointer;
+	vertical-align: middle;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -98,7 +98,7 @@
 	gap: 0.5rem;
 	flex: auto;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: center;
 	width: 100%;
 	height: 100%;
 }

--- a/src/timekeep.test.ts
+++ b/src/timekeep.test.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 
-import { Timekeep, TimeEntry } from "./schema";
+import { Timekeep, TimeEntry, TimeEntryGroup } from "./schema";
 import { defaultSettings, TimekeepSettings } from "./settings";
 import {
 	load,
@@ -17,6 +17,7 @@ import {
 	getEntryDuration,
 	getTotalDuration,
 	getEntriesOrdered,
+	setEntryCollapsed,
 	getUniqueEntryHash,
 	stopRunningEntries,
 	replaceTimekeepCodeblock,
@@ -1521,5 +1522,47 @@ describe("extracting code blocks", () => {
 
 		expect(output[0]).toStrictEqual(inputTimekeep1);
 		expect(output.length).toBe(1);
+	});
+});
+
+describe("collapse state", () => {
+	it("should update group collapse state", () => {
+		const currentTime = moment();
+
+		const input: TimeEntryGroup = {
+			name: "Test",
+			startTime: null,
+			endTime: null,
+			subEntries: [
+				{
+					name: "Test",
+					startTime: currentTime,
+					endTime: currentTime,
+					subEntries: null,
+				},
+			],
+		};
+
+		const collapsed = setEntryCollapsed(input, true);
+
+		expect(collapsed.subEntries).not.toBeNull();
+		expect((collapsed as TimeEntryGroup).collapsed).toBeDefined();
+		expect((collapsed as TimeEntryGroup).collapsed).toBe(true);
+	});
+
+	it("should not set collapse state on single entry", () => {
+		const currentTime = moment();
+
+		const input: TimeEntry = {
+			name: "Test",
+			startTime: currentTime,
+			endTime: currentTime,
+			subEntries: null,
+		};
+
+		const collapsed = setEntryCollapsed(input, true);
+
+		expect(collapsed.subEntries).toBeNull();
+		expect((collapsed as TimeEntryGroup).collapsed).toBeUndefined();
 	});
 });

--- a/src/timekeep.ts
+++ b/src/timekeep.ts
@@ -174,6 +174,24 @@ export function updateEntry(
 }
 
 /**
+ * Updates the collapsed field on a group entry. Normal entries
+ * wont be collapsed since they cannot be
+ *
+ * @param entry The entry to set the collapse state for
+ * @param collapsed The collapse state
+ * @returns The new updated entry
+ */
+export function setEntryCollapsed(
+	entry: TimeEntry,
+	collapsed: boolean
+): TimeEntry {
+	// Entry cannot be collapsed
+	if (entry.subEntries === null) return entry;
+
+	return { ...entry, collapsed };
+}
+
+/**
  * Stops any entries in the provided list that are running
  * returning a list of the new non running entries
  *


### PR DESCRIPTION
## Description

Adds some improvements around how group entries are visually displayed

## Changes
- Underline group entries to show where they start
- Allow collapsing and expanding entries, this is stored in the data JSON (Couldn't get it to stick without this)
- Replaced indent lines with indent padding