### PR TITLE
feat: move start and start nested logic out of components and new tests

### DIFF
--- a/src/components/TimesheetRowEditing.tsx
+++ b/src/components/TimesheetRowEditing.tsx
@@ -79,7 +79,7 @@ export default function TimesheetRowEditing({ entry, onFinishEditing }: Props) {
 
 		// Save the updated entry
 		timekeepStore.setState((timekeep) => ({
-			entries: updateEntry(timekeep.entries, entry, newEntry),
+			entries: updateEntry(timekeep.entries, entry.id, newEntry),
 		}));
 
 		onFinishEditing();

--- a/src/components/TimesheetStart.tsx
+++ b/src/components/TimesheetStart.tsx
@@ -5,8 +5,7 @@ import React, { useMemo, useState, FormEvent } from "react";
 import { useSettings } from "@/contexts/use-settings-context";
 import { useTimekeepStore } from "@/contexts/use-timekeep-store";
 import {
-	withEntry,
-	isKeepRunning,
+	startNewEntry,
 	getPathToEntry,
 	getRunningEntry,
 	stopRunningEntries,
@@ -22,21 +21,17 @@ import ObsidianIcon from "./ObsidianIcon";
 export default function TimekeepStart() {
 	const store = useTimekeepStore();
 	const timekeep = useStore(store);
-	const [name, setName] = useState("");
 	const settings = useSettings();
 
-	const currentEntry = useMemo(
-		() => getRunningEntry(timekeep.entries),
-		[timekeep]
-	);
+	const [name, setName] = useState("");
 
-	const pathToEntry = useMemo(
-		() =>
-			currentEntry
-				? getPathToEntry(timekeep.entries, currentEntry)
-				: null,
-		[timekeep, currentEntry]
-	);
+	const { currentEntry, pathToEntry } = useMemo(() => {
+		const currentEntry = getRunningEntry(timekeep.entries);
+		const pathToEntry = currentEntry
+			? getPathToEntry(timekeep.entries, currentEntry)
+			: null;
+		return { currentEntry, pathToEntry };
+	}, [timekeep]);
 
 	const isTimekeepRunning = currentEntry !== null;
 
@@ -47,17 +42,10 @@ export default function TimekeepStart() {
 
 		store.setState((timekeep) => {
 			const currentTime = moment();
-			let entries = timekeep.entries;
+			const entries = startNewEntry(name, currentTime, timekeep.entries);
 
-			// Stop any already running entries
-			if (isKeepRunning(timekeep)) {
-				// Stop the running entry
-				entries = stopRunningEntries(entries, currentTime);
-			}
-
-			/// Clear the name input
+			// Reset name input
 			setName("");
-			entries = withEntry(entries, name, currentTime);
 
 			return {
 				...timekeep,

--- a/src/timekeep/__fixtures__/manipulating/start_entry/startNestedShouldStopRunning.ts
+++ b/src/timekeep/__fixtures__/manipulating/start_entry/startNestedShouldStopRunning.ts
@@ -1,0 +1,41 @@
+import moment from "moment";
+
+export const currentTime = moment();
+
+export const name = "Block 2";
+export const stopped = "9054dee3-8c15-493b-ad31-f070e08c2699";
+
+export const targetEntry = {
+	id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+	name: "Block",
+	startTime: currentTime,
+	endTime: null,
+	subEntries: null,
+};
+
+export const input = [targetEntry];
+
+export const expected = [
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c269a",
+		name: "Block",
+		startTime: null,
+		endTime: null,
+		subEntries: [
+			{
+				id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+				name: "Part 1",
+				startTime: currentTime,
+				endTime: currentTime,
+				subEntries: null,
+			},
+			{
+				id: "8054dee3-8c15-493b-ad31-f070e08c2699",
+				name: "Part 2",
+				startTime: currentTime,
+				endTime: null,
+				subEntries: null,
+			},
+		],
+	},
+];

--- a/src/timekeep/__fixtures__/manipulating/start_entry/startNotStartedEntry.ts
+++ b/src/timekeep/__fixtures__/manipulating/start_entry/startNotStartedEntry.ts
@@ -1,0 +1,23 @@
+import moment from "moment";
+
+export const currentTime = moment();
+
+export const targetEntry = {
+	id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+	name: "Part 1",
+	startTime: null,
+	endTime: null,
+	subEntries: null,
+};
+
+export const input = [targetEntry];
+
+export const expected = [
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+		name: "Part 1",
+		startTime: currentTime,
+		endTime: null,
+		subEntries: null,
+	},
+];

--- a/src/timekeep/__fixtures__/manipulating/start_entry/startShouldStopRunning.ts
+++ b/src/timekeep/__fixtures__/manipulating/start_entry/startShouldStopRunning.ts
@@ -1,0 +1,48 @@
+import moment from "moment";
+
+export const currentTime = moment();
+
+export const name = "Block 2";
+
+export const stopped = "9054dee3-8c15-493b-ad31-f070e08c2699";
+
+export const input = [
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+		name: "Part 1",
+		startTime: currentTime,
+		endTime: null,
+		subEntries: null,
+	},
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c269a",
+		name: "Part 2",
+		startTime: currentTime,
+		endTime: null,
+		subEntries: null,
+	},
+];
+
+export const expected = [
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+		name: "Part 1",
+		startTime: currentTime,
+		endTime: currentTime,
+		subEntries: null,
+	},
+	{
+		id: "9054dee3-8c15-493b-ad31-f070e08c269a",
+		name: "Part 2",
+		startTime: currentTime,
+		endTime: currentTime,
+		subEntries: null,
+	},
+	{
+		id: "8054dee3-8c15-493b-ad31-f070e08c2699",
+		name: name,
+		startTime: currentTime,
+		endTime: null,
+		subEntries: null,
+	},
+];

--- a/src/timekeep/__fixtures__/path/pathNotFound.ts
+++ b/src/timekeep/__fixtures__/path/pathNotFound.ts
@@ -1,0 +1,14 @@
+import moment from "moment";
+
+export const currentTime = moment();
+
+export const targetEntry = {
+	id: "9054dee3-8c15-493b-ad31-f070e08c2699",
+	name: "Part 1",
+	startTime: currentTime,
+	endTime: currentTime,
+	subEntries: null,
+};
+
+export const entries = [];
+export const expected = [];

--- a/src/timekeep/index.test.ts
+++ b/src/timekeep/index.test.ts
@@ -21,6 +21,7 @@ import {
 	updateEntry,
 	withSubEntry,
 	isKeepRunning,
+	startNewEntry,
 	isEntryRunning,
 	removeSubEntry,
 	getPathToEntry,
@@ -31,6 +32,7 @@ import {
 	setEntryCollapsed,
 	getUniqueEntryHash,
 	stopRunningEntries,
+	startNewNestedEntry,
 } from "./index";
 
 describe("manipulating entries", () => {
@@ -40,7 +42,11 @@ describe("manipulating entries", () => {
 				await import(
 					"./__fixtures__/manipulating/update_entry/updateEntry"
 				);
-			const updated = updateEntry(entries, entryToUpdate, updatedEntry);
+			const updated = updateEntry(
+				entries,
+				entryToUpdate.id,
+				updatedEntry
+			);
 			expect(updated).toEqual(expectedEntries);
 		});
 	});
@@ -93,6 +99,97 @@ describe("manipulating entries", () => {
 			);
 			const updated = removeEntry(entries, entryToRemove);
 			expect(updated).toEqual(expectedEntries);
+		});
+	});
+
+	describe("path to entry", () => {
+		it("path not found", async () => {
+			const { targetEntry, entries, expected } = await import(
+				"./__fixtures__/path/pathNotFound"
+			);
+			const output = getPathToEntry(entries, targetEntry);
+			expect(output).toEqual(expected);
+		});
+
+		it("top level path found", () => {});
+
+		it("deep path found", () => {});
+	});
+
+	describe("start new entry", () => {
+		it("starting a new entry should stop any running entries", async () => {
+			const { currentTime, stopped, name, input, expected } =
+				await import(
+					"./__fixtures__/manipulating/start_entry/startShouldStopRunning"
+				);
+
+			const output = startNewEntry(name, currentTime, input);
+			const stoppedEntry = output.find((entry) => entry.id === stopped);
+
+			expect(stoppedEntry).toBeDefined();
+			expect(stoppedEntry!.endTime).not.toBeNull();
+
+			expect(stripEntriesRuntimeData(output)).toEqual(
+				stripEntriesRuntimeData(expected)
+			);
+		});
+
+		it("starting a new entry should add a new entry", async () => {
+			const { currentTime, name, input, expected } = await import(
+				"./__fixtures__/manipulating/start_entry/startShouldStopRunning"
+			);
+
+			const output = startNewEntry(name, currentTime, input);
+			expect(stripEntriesRuntimeData(output)).toEqual(
+				stripEntriesRuntimeData(expected)
+			);
+		});
+	});
+
+	describe("start non started entry", () => {
+		it("starting a new entry should stop any running entries", async () => {
+			const { currentTime, targetEntry, input, expected } = await import(
+				"./__fixtures__/manipulating/start_entry/startNotStartedEntry"
+			);
+
+			const output = startNewNestedEntry(currentTime, targetEntry, input);
+			expect(stripEntriesRuntimeData(output)).toEqual(
+				stripEntriesRuntimeData(expected)
+			);
+		});
+	});
+
+	describe("start new nested entry", () => {
+		it("starting a new entry should stop any running entries", async () => {
+			const { currentTime, stopped, targetEntry, input, expected } =
+				await import(
+					"./__fixtures__/manipulating/start_entry/startNestedShouldStopRunning"
+				);
+
+			const output = startNewNestedEntry(currentTime, targetEntry, input);
+
+			const outerEntry = output[0];
+			const stoppedEntry = outerEntry.subEntries?.find(
+				(entry) => entry.id === stopped
+			);
+
+			expect(stoppedEntry).toBeDefined();
+			expect(stoppedEntry!.endTime).not.toBeNull();
+
+			expect(stripEntriesRuntimeData(output)).toEqual(
+				stripEntriesRuntimeData(expected)
+			);
+		});
+
+		it("starting a new entry should add a new entry", async () => {
+			const { currentTime, targetEntry, input, expected } = await import(
+				"./__fixtures__/manipulating/start_entry/startNestedShouldStopRunning"
+			);
+
+			const output = startNewNestedEntry(currentTime, targetEntry, input);
+			expect(stripEntriesRuntimeData(output)).toEqual(
+				stripEntriesRuntimeData(expected)
+			);
 		});
 	});
 


### PR DESCRIPTION
## Description

More testing logic and moving logic out of components to be more testable

## Changes
- Tests for starting top level entry
- Tests for starting nested entry
- Tests for starting non started entry
- Moved starting logic out of components

## Related Issues

- Tests are built to catch things like #40 that occured outside of the tested logic