### PR TITLE
Feat edit running entry name

### DIFF
--- a/src/components/TimesheetStart.tsx
+++ b/src/components/TimesheetStart.tsx
@@ -97,7 +97,7 @@ export default function TimekeepStart() {
 	return (
 		<div>
 			{editing ? (
-				/* Start new entry */
+				/* Edit the name of the current entry */
 				<form
 					className="timekeep-start-area"
 					data-area="start"


### PR DESCRIPTION
## Description 

Adds an edit button next to the currently running section to allow editing the name of the currently running entry

<img width="1141" height="175" alt="image" src="https://github.com/user-attachments/assets/38264c72-5b7b-4142-83d5-b7fd2e7ce9b3" />
<img width="1195" height="214" alt="image" src="https://github.com/user-attachments/assets/b0a82853-fbb1-47d6-b86c-db5f4f68f91a" />

## Related Issues
- Closes #39 