### PR TITLE
feat: timekeep merger

### DIFF
--- a/src/components/TimesheetExportActions.tsx
+++ b/src/components/TimesheetExportActions.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import moment from "moment";
-import * as path from "path";
-import { existsSync } from "fs";
 import { Notice } from "obsidian";
 import { Platform } from "obsidian";
-import { mkdir, writeFile } from "fs/promises";
-import { PdfExportBehavior } from "@/settings";
+import { exportPdf } from "@/export/pdf";
 import { createCSV, createMarkdownTable } from "@/export";
 import { stripTimekeepRuntimeData } from "@/timekeep/schema";
 import { useSettings } from "@/contexts/use-settings-context";
@@ -53,74 +50,7 @@ export default function TimekeepExportActions() {
 
 	const onSavePDF = async () => {
 		const timekeep = timekeepStore.getState();
-
-		// Pdf exports don't work in mobile mode
-		if (Platform.isMobileApp) return;
-
-		// Dynamic imports to prevent them from causing errors when loaded (Because they are unsupported on mobile)
-		const electron = require("electron");
-		const { pdf } = require("@/pdf");
-		const pdfModule = require("@/components/pdf");
-
-		const currentTime = moment();
-
-		// Prompt user for save location
-		const result = await electron.remote.dialog.showSaveDialog({
-			title: "Save timesheet",
-			defaultPath: "Timesheet.pdf",
-			filters: [{ extensions: ["pdf"], name: "PDF" }],
-			properties: ["showOverwriteConfirmation", "createDirectory"],
-		});
-
-		if (result.canceled) {
-			return;
-		}
-
-		const outputPath = result.filePath;
-		if (outputPath === undefined) {
-			return;
-		}
-		const TimesheetPdf = pdfModule.default;
-
-		// Create the PDF
-		const createdPdf = pdf(
-			<TimesheetPdf
-				data={timekeep}
-				title={settings.pdfTitle}
-				footnote={settings.pdfFootnote}
-				currentTime={currentTime}
-				settings={settings}
-			/>
-		);
-
-		// Create a blob from the PDF
-		const buffer = await createdPdf.toBuffer();
-
-		const fullOutputPath = path.normalize(outputPath);
-		const fullOutputDir = path.dirname(fullOutputPath);
-
-		// Create output directory if missing
-		if (!existsSync(fullOutputDir)) {
-			await mkdir(fullOutputDir);
-		}
-
-		try {
-			await writeFile(outputPath, buffer);
-
-			new Notice("Export successful", 1500);
-
-			// Open the directory using the system explorer
-			if (settings.pdfExportBehavior == PdfExportBehavior.OPEN_PATH) {
-				electron.remote.shell.showItemInFolder(fullOutputPath);
-			}
-
-			// Open the exported file
-			if (settings.pdfExportBehavior == PdfExportBehavior.OPEN_FILE) {
-				await electron.remote.shell.openPath(fullOutputPath);
-			}
-		} catch (error) {
-			console.error("Failed to write pdf file", error);
-		}
+		exportPdf(timekeep, settings);
 	};
 
 	return (

--- a/src/export/pdf.ts
+++ b/src/export/pdf.ts
@@ -1,0 +1,81 @@
+import React from "react";
+import moment from "moment";
+import * as path from "path";
+import { existsSync } from "fs";
+import { Notice, Platform } from "obsidian";
+import { Timekeep } from "@/timekeep/schema";
+import { mkdir, writeFile } from "fs/promises";
+import { TimekeepSettings, PdfExportBehavior } from "@/settings";
+
+export async function exportPdf(
+	timekeep: Timekeep,
+	settings: TimekeepSettings
+) {
+	// Pdf exports don't work in mobile mode
+	if (Platform.isMobileApp) return;
+
+	// Dynamic imports to prevent them from causing errors when loaded (Because they are unsupported on mobile)
+	const electron = require("electron");
+	const { pdf } = require("@/pdf");
+	const pdfModule = require("@/components/pdf");
+
+	const currentTime = moment();
+
+	// Prompt user for save location
+	const result = await electron.remote.dialog.showSaveDialog({
+		title: "Save timesheet",
+		defaultPath: "Timesheet.pdf",
+		filters: [{ extensions: ["pdf"], name: "PDF" }],
+		properties: ["showOverwriteConfirmation", "createDirectory"],
+	});
+
+	if (result.canceled) {
+		return;
+	}
+
+	const outputPath = result.filePath;
+	if (outputPath === undefined) {
+		return;
+	}
+	const TimesheetPdf = pdfModule.default;
+
+	const document = React.createElement(TimesheetPdf, {
+		data: timekeep,
+		title: settings.pdfTitle,
+		footnote: settings.pdfFootnote,
+		currentTime,
+		settings,
+	});
+
+	// Create the PDF
+	const createdPdf = pdf(document);
+
+	// Create a blob from the PDF
+	const buffer = await createdPdf.toBuffer();
+
+	const fullOutputPath = path.normalize(outputPath);
+	const fullOutputDir = path.dirname(fullOutputPath);
+
+	// Create output directory if missing
+	if (!existsSync(fullOutputDir)) {
+		await mkdir(fullOutputDir);
+	}
+
+	try {
+		await writeFile(outputPath, buffer);
+
+		new Notice("Export successful", 1500);
+
+		// Open the directory using the system explorer
+		if (settings.pdfExportBehavior == PdfExportBehavior.OPEN_PATH) {
+			electron.remote.shell.showItemInFolder(fullOutputPath);
+		}
+
+		// Open the exported file
+		if (settings.pdfExportBehavior == PdfExportBehavior.OPEN_FILE) {
+			await electron.remote.shell.openPath(fullOutputPath);
+		}
+	} catch (error) {
+		console.error("Failed to write pdf file", error);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
 } from "@/timekeep";
 
 import { Timekeep, TimeEntry } from "./timekeep/schema";
+import { TimekeepMergerModal } from "./views/timekeep-merger-modal";
 import { TimekeepMarkdownView } from "./views/timekeep-markdown-view";
 import { TimekeepLocatorModal } from "./views/timekeep-locator-modal";
 
@@ -101,6 +102,12 @@ export default class TimekeepPlugin extends Plugin {
 			id: `find`,
 			name: `Find running trackers`,
 			callback: () => new TimekeepLocatorModal(this.app).open(),
+		});
+
+		this.addCommand({
+			id: `create-merged`,
+			name: `Create Merged Tracker`,
+			callback: () => new TimekeepMergerModal(this.app).open(),
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,23 @@ export default class TimekeepPlugin extends Plugin {
 		this.addCommand({
 			id: `create-merged`,
 			name: `Create Merged Tracker`,
-			callback: () => new TimekeepMergerModal(this.app).open(),
+			callback: () =>
+				new TimekeepMergerModal(
+					this.app,
+					this.settingsStore,
+					false
+				).open(),
+		});
+
+		this.addCommand({
+			id: `export-merged-pdf`,
+			name: `Export Merged Tracker PDF`,
+			callback: () =>
+				new TimekeepMergerModal(
+					this.app,
+					this.settingsStore,
+					true
+				).open(),
 		});
 	}
 }

--- a/src/views/timekeep-merger-modal.ts
+++ b/src/views/timekeep-merger-modal.ts
@@ -1,0 +1,208 @@
+import { v4 as uuid } from "uuid";
+import { extractTimekeepCodeblocks } from "@/timekeep/parser";
+import { Timekeep, stripTimekeepRuntimeData } from "@/timekeep/schema";
+import { App, TFile, Modal, TextComponent, ButtonComponent } from "obsidian";
+
+interface TimekeepResult {
+	timekeep: Timekeep;
+	file: TFile;
+	index: number;
+	id: string;
+}
+
+export class TimekeepMergerModal extends Modal {
+	private results: TimekeepResult[] = [];
+	private filteredResults: TimekeepResult[] = [];
+	private selectedResults: TimekeepResult[] = [];
+
+	private listContainer: HTMLElement | undefined;
+	private searchInput: TextComponent | undefined;
+	private loadingEl: HTMLElement | undefined;
+
+	constructor(app: App) {
+		super(app);
+
+		this.setTitle("Create merged timekeep");
+	}
+
+	async onOpen(): Promise<void> {
+		this.contentEl.empty();
+		this.contentEl.createEl("p", {
+			text: "Select Timekeep Entries to Merge",
+		});
+
+		this.loadingEl = this.contentEl.createDiv({
+			text: "Loading timekeep entries...",
+		});
+		this.loadingEl.style.marginBottom = "1rem";
+		this.loadingEl.style.opacity = "0.7";
+
+		this.searchInput = new TextComponent(this.contentEl);
+		this.searchInput.setPlaceholder("Search by file path...");
+		this.searchInput.inputEl.style.width = "100%";
+		this.searchInput.setDisabled(true);
+		this.searchInput.onChange(() => {
+			this.updateFilteredResults();
+			this.renderList();
+		});
+
+		this.listContainer = this.contentEl.createDiv();
+		this.listContainer.style.maxHeight = "400px";
+		this.listContainer.style.overflowY = "auto";
+		this.listContainer.style.marginTop = "1em";
+		this.listContainer.style.padding = "0.25em";
+
+		const footer = this.contentEl.createDiv();
+		footer.style.display = "flex";
+		footer.style.flexFlow = "row";
+		footer.style.gap = "1rem";
+		footer.style.marginTop = "1rem";
+
+		const mergeButton = new ButtonComponent(footer)
+			.setButtonText("Create")
+			.setCta()
+			.setDisabled(true)
+			.onClick(() => {
+				const timekeep: Timekeep = {
+					entries: [],
+				};
+
+				for (const result of this.selectedResults) {
+					timekeep.entries = [
+						...timekeep.entries,
+						...result.timekeep.entries,
+					];
+				}
+
+				// Close after taking the results as closing resets the list
+				this.close();
+
+				const editor = this.app.workspace.activeEditor?.editor;
+
+				if (editor) {
+					editor.replaceSelection(
+						`\n\`\`\`timekeep\n${JSON.stringify(stripTimekeepRuntimeData(timekeep))}\n\`\`\`\n`
+					);
+				}
+			});
+
+		new ButtonComponent(footer).setButtonText("Cancel").onClick(() => {
+			this.close();
+		});
+
+		try {
+			this.results = await this.getResults();
+
+			this.updateFilteredResults();
+			this.renderList();
+
+			this.loadingEl.remove();
+			mergeButton.setDisabled(false);
+			this.searchInput.setDisabled(false);
+		} catch (err) {
+			console.error(err);
+			this.loadingEl.setText("Failed to load timekeep entries.");
+			this.loadingEl.style.opacity = "1";
+		}
+	}
+
+	updateFilteredResults() {
+		if (!this.searchInput) return;
+
+		const queryLower = this.searchInput.getValue().toLowerCase().trim();
+		if (queryLower.length < 1) {
+			this.filteredResults = this.results;
+			return;
+		}
+
+		this.filteredResults = this.results.filter((result) => {
+			return result.file.path.toLowerCase().contains(queryLower);
+		});
+	}
+
+	async getResults(): Promise<TimekeepResult[]> {
+		const markdownFiles = this.app.vault.getMarkdownFiles();
+		const batchSize = 25;
+
+		const results: TimekeepResult[] = [];
+
+		for (let i = 0; i < markdownFiles.length; i += batchSize) {
+			const batch = markdownFiles.slice(i, i + batchSize);
+
+			await Promise.allSettled(
+				batch.map(async (file) => {
+					const content = await this.app.vault.cachedRead(file);
+					const codeblocks = extractTimekeepCodeblocks(content);
+
+					for (let i = 0; i < codeblocks.length; i += 1) {
+						results.push({
+							timekeep: codeblocks[i],
+							file,
+							index: i,
+							id: uuid(),
+						});
+					}
+				})
+			);
+		}
+		return results;
+	}
+
+	private renderList() {
+		if (!this.listContainer) {
+			return;
+		}
+
+		this.listContainer.empty();
+		for (const result of this.filteredResults) {
+			const itemEl = this.listContainer.createEl("label", {
+				cls: "timekeep-item",
+			});
+			itemEl.htmlFor = `timekeep-${result.id}`;
+			itemEl.style.display = "flex";
+			itemEl.style.alignItems = "center";
+			itemEl.style.padding = "0.5em";
+			itemEl.style.gap = "0.5em";
+
+			const checkbox = itemEl.createEl("input", { type: "checkbox" });
+			checkbox.style.marginRight = "0.5em";
+			checkbox.checked =
+				this.selectedResults.find((other) => other.id === result.id) !==
+				undefined;
+			checkbox.id = `timekeep-${result.id}`;
+
+			checkbox.onchange = () => {
+				if (checkbox.checked) {
+					this.selectedResults = [...this.selectedResults, result];
+				} else {
+					this.selectedResults = this.selectedResults.filter(
+						(other) => other.id !== result.id
+					);
+				}
+			};
+
+			const label = itemEl.createDiv();
+			label.style.flexGrow = "1";
+			label.style.display = "flex";
+			label.style.flexFlow = "column";
+
+			const title = label.createEl("span");
+			title.textContent = `${result.file.basename}: Timekeep ${result.index + 1}`;
+
+			const path = label.createEl("span");
+			path.textContent = `${result.file.path}`;
+			path.style.opacity = "0.7";
+		}
+	}
+
+	onClose(): void {
+		this.results = [];
+		this.filteredResults = [];
+		this.selectedResults = [];
+		this.contentEl.empty();
+
+		this.searchInput = undefined;
+		this.listContainer = undefined;
+		this.loadingEl = undefined;
+	}
+}


### PR DESCRIPTION
## Description

Adds two new actions 

<img width="1141" height="307" alt="image" src="https://github.com/user-attachments/assets/424a6758-f83e-49ed-8999-b41747d5f8bc" />

### Create Merged Tracker

Opens a modal that allows you to select multiple timekeeps, pressing "Create" will then create a new timekeep at your current cursor position that will be made up of a combination of the entries from all the selected trackers. (I use this as a I often merge many timekeeps from daily notes into a single big one for invoicing)

<img width="879" height="519" alt="image" src="https://github.com/user-attachments/assets/7a4c23dd-3977-4c26-ab21-900a168ba6a5" />

### Export Merged Tracker PDF

Same as create merged tracker but instead of creating a new tracker it will directly export the merged results as a PDF as if "Save PDF" was used

<img width="880" height="528" alt="image" src="https://github.com/user-attachments/assets/5ecbd110-1f7b-43af-b3cd-9d2b5d59cf54" />


