### PR TITLE
feat: custom output formats api

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Store, useStore } from "@/store";
 import { Timekeep } from "@/timekeep/schema";
 import { App as ObsidianApp } from "obsidian";
 import { TimekeepSettings } from "@/settings";
+import { CustomOutputFormat } from "@/output";
 import { AppContext } from "@/contexts/use-app-context";
 import TimesheetStart from "@/components/TimesheetStart";
 import TimesheetTable from "@/components/TimesheetTable";
@@ -11,6 +12,8 @@ import TimesheetSaveError from "@/components/TimesheetSaveError";
 import { SettingsContext } from "@/contexts/use-settings-context";
 import { TimekeepStoreContext } from "@/contexts/use-timekeep-store";
 import TimesheetExportActions from "@/components/TimesheetExportActions";
+
+import { CustomOutputFormatsContext } from "./contexts/use-custom-output-formats";
 
 export type AppProps = {
 	// Obsidian app for creating modals
@@ -21,6 +24,8 @@ export type AppProps = {
 	saveErrorStore: Store<boolean>;
 	// Timekeep settings store
 	settingsStore: Store<TimekeepSettings>;
+	// Custom output formats store
+	customOutputFormats: Store<Record<string, CustomOutputFormat>>;
 	// Callback to save the timekeep
 	handleSaveTimekeep: (value: Timekeep) => Promise<void>;
 };
@@ -34,28 +39,33 @@ export default function App({
 	timekeepStore,
 	saveErrorStore,
 	settingsStore,
+	customOutputFormats,
 	handleSaveTimekeep,
 }: AppProps) {
 	const settings = useStore(settingsStore);
+	const customOutputFormatsState = useStore(customOutputFormats);
 	const saveError = useStore(saveErrorStore);
 
 	return (
 		<AppContext.Provider value={app}>
 			<SettingsContext.Provider value={settings}>
 				<TimekeepStoreContext.Provider value={timekeepStore}>
-					{saveError ? (
-						// Error page when saving fails
-						<TimesheetSaveError
-							handleSaveTimekeep={handleSaveTimekeep}
-						/>
-					) : (
-						<div className="timekeep-container">
-							<TimesheetCounters />
-							<TimesheetStart />
-							<TimesheetTable />
-							<TimesheetExportActions />
-						</div>
-					)}
+					<CustomOutputFormatsContext.Provider
+						value={customOutputFormatsState}>
+						{saveError ? (
+							// Error page when saving fails
+							<TimesheetSaveError
+								handleSaveTimekeep={handleSaveTimekeep}
+							/>
+						) : (
+							<div className="timekeep-container">
+								<TimesheetCounters />
+								<TimesheetStart />
+								<TimesheetTable />
+								<TimesheetExportActions />
+							</div>
+						)}
+					</CustomOutputFormatsContext.Provider>
 				</TimekeepStoreContext.Provider>
 			</SettingsContext.Provider>
 		</AppContext.Provider>

--- a/src/components/TimesheetExportActions.tsx
+++ b/src/components/TimesheetExportActions.tsx
@@ -7,10 +7,12 @@ import { createCSV, createMarkdownTable } from "@/export";
 import { stripTimekeepRuntimeData } from "@/timekeep/schema";
 import { useSettings } from "@/contexts/use-settings-context";
 import { useTimekeepStore } from "@/contexts/use-timekeep-store";
+import { useCustomOutputFormats } from "@/contexts/use-custom-output-formats";
 
 export default function TimekeepExportActions() {
 	const settings = useSettings();
 	const timekeepStore = useTimekeepStore();
+	const customOutputFormats = useCustomOutputFormats();
 
 	const onCopyMarkdown = () => {
 		const timekeep = timekeepStore.getState();
@@ -61,6 +63,18 @@ export default function TimekeepExportActions() {
 			{!Platform.isMobileApp && (
 				<button onClick={onSavePDF}>Save PDF</button>
 			)}
+
+			{Object.entries(customOutputFormats).map(([key, outputFormat]) => (
+				<button
+					key={key}
+					onClick={() => {
+						const timekeep = timekeepStore.getState();
+						const currentTime = moment();
+						outputFormat.onExport(timekeep, settings, currentTime);
+					}}>
+					{outputFormat.getButtonLabel()}
+				</button>
+			))}
 		</div>
 	);
 }

--- a/src/contexts/use-custom-output-formats.ts
+++ b/src/contexts/use-custom-output-formats.ts
@@ -1,0 +1,10 @@
+import React, { useContext } from "react";
+import { CustomOutputFormat } from "@/output";
+
+export const CustomOutputFormatsContext = React.createContext<
+	Record<string, CustomOutputFormat>
+>({});
+
+export function useCustomOutputFormats(): Record<string, CustomOutputFormat> {
+	return useContext(CustomOutputFormatsContext);
+}

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,25 @@
+import { Moment } from "moment";
+
+import { Timekeep } from "./timekeep/schema";
+import { TimekeepSettings } from "./settings";
+
+export interface CustomOutputFormat {
+	/**
+	 * Get the label to display on the export button
+	 * in the user interface
+	 */
+	getButtonLabel(): string;
+
+	/**
+	 * Handle exporting with the custom output format
+	 *
+	 * @param timekeep The timekeep to export
+	 * @param settings The timekeep settings
+	 * @param currentTime The current time to use for unfinished entries
+	 */
+	onExport(
+		timekeep: Timekeep,
+		settings: TimekeepSettings,
+		currentTime: Moment
+	): void;
+}

--- a/src/views/timekeep-markdown-view.ts
+++ b/src/views/timekeep-markdown-view.ts
@@ -4,6 +4,7 @@ import React, { StrictMode } from "react";
 import { Store, createStore } from "@/store";
 import { App as ObsidianApp } from "obsidian";
 import { TimekeepSettings } from "@/settings";
+import { CustomOutputFormat } from "@/output";
 import { Root, createRoot } from "react-dom/client";
 import { Timekeep, stripTimekeepRuntimeData } from "@/timekeep/schema";
 import { LoadResult, replaceTimekeepCodeblock } from "@/timekeep/parser";
@@ -19,6 +20,8 @@ export class TimekeepMarkdownView extends MarkdownRenderChild {
 	app: ObsidianApp;
 	// Timekeep settings store
 	settingsStore: Store<TimekeepSettings>;
+	// Custom output formats store
+	customOutputFormats: Store<Record<string, CustomOutputFormat>>;
 	// Markdown context for the current markdown block
 	context: MarkdownPostProcessorContext;
 	// Timekeep load result
@@ -32,12 +35,14 @@ export class TimekeepMarkdownView extends MarkdownRenderChild {
 		containerEl: HTMLElement,
 		app: ObsidianApp,
 		settingsStore: Store<TimekeepSettings>,
+		customOutputFormats: Store<Record<string, CustomOutputFormat>>,
 		context: MarkdownPostProcessorContext,
 		loadResult: LoadResult
 	) {
 		super(containerEl);
 		this.app = app;
 		this.settingsStore = settingsStore;
+		this.customOutputFormats = customOutputFormats;
 		this.context = context;
 		this.loadResult = loadResult;
 		this.root = createRoot(containerEl);
@@ -97,6 +102,7 @@ export class TimekeepMarkdownView extends MarkdownRenderChild {
 						timekeepStore,
 						saveErrorStore,
 						settingsStore: this.settingsStore,
+						customOutputFormats: this.customOutputFormats,
 						handleSaveTimekeep,
 					})
 				)


### PR DESCRIPTION
## Description

Exposes new API functions to allow other plugins and tools to dynamically at runtime add custom export methods to timekeep making it extensible by other plugins that with to add other export file formats or methods (Sky is the limit here)

## Changes

- Added registerCustomOutputFormat 
- Added unregisterCustomOutputFormat 
- Exposed replaceTimekeepCodeblock (Can be useful to people trying to modify timekeep blocks through the API)


