### PR TITLE
fix: track rename events in timekeep registry

### DIFF
--- a/src/service/registry.test.ts
+++ b/src/service/registry.test.ts
@@ -717,7 +717,7 @@ describe("TimekeepRegistry", () => {
 
 			registry.load();
 
-			expect(vault.on).toHaveBeenCalledTimes(3);
+			expect(vault.on).toHaveBeenCalledTimes(4);
 		});
 
 		it("un-registers vault events when switching from enabled to disabled", () => {
@@ -728,11 +728,11 @@ describe("TimekeepRegistry", () => {
 
 			registry.load();
 
-			expect(vault.on).toHaveBeenCalledTimes(3);
+			expect(vault.on).toHaveBeenCalledTimes(4);
 
 			settings.setState({ ...defaultSettings, registryEnabled: false });
 
-			expect(vault.offref).toHaveBeenCalledTimes(3);
+			expect(vault.offref).toHaveBeenCalledTimes(4);
 		});
 
 		it("handle loading failure", async () => {

--- a/src/service/registry.ts
+++ b/src/service/registry.ts
@@ -123,10 +123,11 @@ export class TimekeepRegistry extends Component {
 		// Attach vault events
 		const createEvent = this.#vault.on("create", this.onFileCreated.bind(this));
 		const modifyEvent = this.#vault.on("modify", this.onFileModified.bind(this));
+		const renameEvent = this.#vault.on("rename", this.onFileModified.bind(this));
 		const deleteEvent = this.#vault.on("delete", this.onFileRemoved.bind(this));
 
 		// Register events for unloading
-		this.events.push(createEvent, modifyEvent, deleteEvent);
+		this.events.push(createEvent, modifyEvent, renameEvent, deleteEvent);
 
 		// Load the registry from the vault
 		this.registerTask("loadFromVault", this.loadFromVault());


### PR DESCRIPTION
## Description

Ensures file rename events cause registry updates so that file name changes are handled in the registry