### PR TITLE
feat: patch away the internal fetch logic from pdfmake

### DIFF
--- a/patches/pdfmake.patch
+++ b/patches/pdfmake.patch
@@ -1,0 +1,80 @@
+diff --git a/build/pdfmake.js b/build/pdfmake.js
+index 97e3b9b54d6a885a0d9c73c03dec538c0d5a8b7d..4322c19c79e9a15ca7f4f70c8f03dc51583a01da 100644
+--- a/build/pdfmake.js
++++ b/build/pdfmake.js
+@@ -8517,56 +8517,6 @@ function calculatePageHeight(page, margins) {
+ // EXTERNAL MODULE: ./src/virtual-fs.js
+ var virtual_fs = __webpack_require__(6811);
+ ;// ./src/URLResolver.js
+-const MAX_REDIRECTS = 30;
+-
+-/**
+- * @param {string} url
+- * @param {object} headers
+- * @param {(url: string) => boolean} urlAccessPolicy
+- * @returns {Promise<Response>}
+- */
+-async function fetchUrl(url, headers, urlAccessPolicy) {
+-  if (headers === void 0) {
+-    headers = {};
+-  }
+-  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+-    if (typeof urlAccessPolicy !== 'undefined' && urlAccessPolicy(url) !== true) {
+-      throw new Error(`Access to URL denied by resource access policy: ${url}`);
+-    }
+-    try {
+-      let response = await fetch(url, {
+-        headers,
+-        redirect: 'manual'
+-      });
+-
+-      // redirect url
+-      if (response.status >= 300 && response.status < 400) {
+-        let location = response.headers.get('location');
+-        if (!location) {
+-          throw new Error('Redirect response missing Location header');
+-        }
+-        url = new URL(location, url).href;
+-        continue;
+-      }
+-
+-      // browsers do not support redirect: 'manual'
+-      if (response.type === 'opaqueredirect') {
+-        response = await fetch(url, {
+-          headers
+-        });
+-      }
+-      if (!response.ok) {
+-        throw new Error(`Failed to fetch (status code: ${response.status})`);
+-      }
+-      return response;
+-    } catch (error) {
+-      throw new Error(`Network request failed (url: "${url}", error: ${error.message})`, {
+-        cause: error
+-      });
+-    }
+-  }
+-  throw new Error(`Network request failed (url: "${url}", error: Too many redirects)`);
+-}
+ class URLResolver {
+   constructor(fs) {
+     this.fs = fs;
+@@ -8589,16 +8539,8 @@ class URLResolver {
+         if (this.fs.existsSync(url)) {
+           return; // url was downloaded earlier
+         }
+-        const response = await fetchUrl(url, headers, this.urlAccessPolicy);
+-
+-        // validate access policy on redirected url (in browsers, only the final URL is validated)
+-        if (response.redirected) {
+-          if (typeof this.urlAccessPolicy !== 'undefined' && this.urlAccessPolicy(response.url) !== true) {
+-            throw new Error(`Access to URL denied by resource access policy: ${response.url}`);
+-          }
+-        }
+-        const buffer = await response.arrayBuffer();
+-        this.fs.writeFileSync(url, buffer);
++        
++		throw new Error("External resource loading disallowed by obsidian-timekeep")
+       }
+       // else cannot be resolved
+     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  pdfmake:
+    hash: 6d54e252a007864832feb784df02f056f9ea1b527c0d79fc05b23b31db3c6e73
+    path: patches/pdfmake.patch
+
 importers:
 
   .:
@@ -19,7 +24,7 @@ importers:
         version: 7.3.0
       pdfmake:
         specifier: ^0.3.7
-        version: 0.3.8
+        version: 0.3.8(patch_hash=6d54e252a007864832feb784df02f056f9ea1b527c0d79fc05b23b31db3c6e73)
       valibot:
         specifier: ^1.4.0
         version: 1.4.0(typescript@6.0.2)
@@ -1657,7 +1662,7 @@ snapshots:
       linebreak: 1.1.0
       png-js: 1.1.0
 
-  pdfmake@0.3.8:
+  pdfmake@0.3.8(patch_hash=6d54e252a007864832feb784df02f056f9ea1b527c0d79fc05b23b31db3c6e73):
     dependencies:
       linebreak: 1.1.0
       pdfkit: 0.18.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  pdfmake: patches/pdfmake.patch

--- a/src/export/pdf/definition.ts
+++ b/src/export/pdf/definition.ts
@@ -1,8 +1,6 @@
 import type { Moment } from "moment";
 import type { Content, DynamicContent, TableCell, TDocumentDefinitions } from "pdfmake/interfaces";
 
-import pdfMake from "pdfmake";
-
 import type { TimekeepSettings } from "@/settings";
 
 import { NameSegmentType, parseNameSegments } from "@/utils/name";
@@ -98,8 +96,8 @@ function createPdfHeader(
 	currentDate: string,
 	totalDuration: string,
 	totalDurationShort: string
-): pdfMake.Content {
-	const detail = (title: string, value: string): pdfMake.Content => ({
+): Content {
+	const detail = (title: string, value: string): Content => ({
 		text: [
 			{ text: title + ": ", fontSize: 8, bold: true },
 			{ text: value, fontSize: 8 },
@@ -151,7 +149,7 @@ function createPdfTable(
 	totalDuration: string,
 	settings: TimekeepSettings,
 	currentTime: Moment
-): pdfMake.Content {
+): Content {
 	const rows = createPdfTableRows(timekeep.entries, settings, currentTime);
 
 	const cellPadding = () => 8;


### PR DESCRIPTION
## Description

pdfmake has some code for fetching assets like images and such from URLs at runtime this is negatively impacting my obsidian plugin community scorecard and is not used by timekeep so I'm patching it out of the library so that obsidian doesn't flag timekeep as "suspicious" for something we don't actually do:

<img width="1120" height="239" alt="image" src="https://github.com/user-attachments/assets/ee1b9303-b970-4bd9-b33c-7f175de34db7" />

(The lint here is mislead since it doesn't actually check that the setInterval and fetch are connected in any way, the setInterval code is completely separate from the)