### PR TITLE
feat: generic entry handling in status bar item

### DIFF
--- a/src/components/TimesheetNameInput/TimesheetNameInput.test.ts
+++ b/src/components/TimesheetNameInput/TimesheetNameInput.test.ts
@@ -164,9 +164,7 @@ describe("TimesheetNameInput", () => {
 					expect(suggestion.innerHTML).toBe("<mark>Test</mark>");
 					break;
 				case "Before Test After":
-					expect(suggestion.innerHTML).toBe(
-						"Before <mark>Test</mark> After"
-					);
+					expect(suggestion.innerHTML).toBe("Before <mark>Test</mark> After");
 					break;
 				case "Before Test":
 					expect(suggestion.innerHTML).toBe("Before <mark>Test</mark>");
@@ -175,9 +173,7 @@ describe("TimesheetNameInput", () => {
 					expect(suggestion.innerHTML).toBe("<mark>Test</mark> After");
 					break;
 				case "Test After Test":
-					expect(suggestion.innerHTML).toBe(
-						"<mark>Test</mark> After <mark>Test</mark>"
-					);
+					expect(suggestion.innerHTML).toBe("<mark>Test</mark> After <mark>Test</mark>");
 					break;
 				default:
 					throw new Error("unexpected text content");

--- a/src/components/TimesheetStatusBar/TimesheetStatusBar.ts
+++ b/src/components/TimesheetStatusBar/TimesheetStatusBar.ts
@@ -7,7 +7,7 @@ import { assert } from "@/utils/assert";
 
 import { TimesheetStatusBarItem } from "./TimesheetStatusBarItem";
 
-import { TimeEntry } from "@/timekeep/schema";
+import { TimeEntry, Timekeep } from "@/timekeep/schema";
 
 import { TimekeepRegistry, TimekeepRegistryItemRef } from "@/service/registry";
 
@@ -74,11 +74,21 @@ export class TimesheetStatusBar extends Component {
 
 		// Load the new children
 		for (const runningEntry of runningEntries) {
-			this.renderEntry(runningEntry.running, runningEntry.ref, settings);
+			this.renderEntry(
+				runningEntry.running,
+				runningEntry.ref,
+				runningEntry.timekeep,
+				settings
+			);
 		}
 	}
 
-	renderEntry(entry: TimeEntry, ref: TimekeepRegistryItemRef, settings: TimekeepSettings) {
+	renderEntry(
+		entry: TimeEntry,
+		ref: TimekeepRegistryItemRef,
+		timekeep: Timekeep,
+		settings: TimekeepSettings
+	) {
 		const wrapperEl = this.wrapperEl;
 		assert(wrapperEl, "Wrapper element should be defined on render");
 		const item = new TimesheetStatusBarItem(
@@ -87,6 +97,7 @@ export class TimesheetStatusBar extends Component {
 			this.registry,
 			settings,
 			entry,
+			timekeep,
 			ref
 		);
 		this.items.push(item);

--- a/src/components/TimesheetStatusBar/TimesheetStatusBarItem.test.ts
+++ b/src/components/TimesheetStatusBar/TimesheetStatusBarItem.test.ts
@@ -10,7 +10,7 @@ import { createStore, Store } from "@/store";
 
 import { TimesheetStatusBarItem } from "./TimesheetStatusBarItem";
 
-import { TimeEntry } from "@/timekeep/schema";
+import { TimeEntry, Timekeep } from "@/timekeep/schema";
 
 import { TimekeepEntryItemType, TimekeepRegistry } from "@/service/registry";
 
@@ -56,6 +56,7 @@ describe("TimesheetStatusBarItem", () => {
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: false },
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -72,8 +73,8 @@ describe("TimesheetStatusBarItem", () => {
 			app,
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: false },
-
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -104,8 +105,8 @@ describe("TimesheetStatusBarItem", () => {
 			app,
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: false },
-
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -128,8 +129,8 @@ describe("TimesheetStatusBarItem", () => {
 			app,
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: false },
-
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -156,8 +157,8 @@ describe("TimesheetStatusBarItem", () => {
 			app,
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: true },
-
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -180,6 +181,7 @@ describe("TimesheetStatusBarItem", () => {
 			registry,
 			{ ...defaultSettings, statusBarShowFolderPath: false },
 			entry,
+			{ entries: [entry] },
 			{
 				file,
 				type: TimekeepEntryItemType.FILE,
@@ -192,5 +194,229 @@ describe("TimesheetStatusBarItem", () => {
 		expect(nameEl).not.toBeNull();
 
 		expect(nameEl!.textContent.startsWith("nested/path: ")).not.toBeTruthy();
+	});
+
+	it("non generic parent name should be used when statusBarPreferNonGenericParent is true", () => {
+		const file = vault.addFile("nested/path/test.timekeep", "");
+
+		const runningEntry = {
+			id: 4,
+			name: "Part 2",
+			startTime: moment(start),
+			endTime: null,
+			subEntries: null,
+		};
+
+		const entry: TimeEntry = {
+			id: 1,
+			name: "Good block name",
+			startTime: null,
+			endTime: null,
+			subEntries: [
+				{
+					id: 2,
+					name: "Part 1",
+					startTime: null,
+					endTime: null,
+					subEntries: [
+						{
+							id: 3,
+							name: "Part 1",
+							startTime: moment(start),
+							endTime: moment(start),
+							subEntries: null,
+						},
+						runningEntry,
+					],
+				},
+			],
+		};
+
+		const timekeep: Timekeep = { entries: [entry] };
+
+		const component = new TimesheetStatusBarItem(
+			containerEl,
+			app,
+			registry,
+			{
+				...defaultSettings,
+				statusBarShowFolderPath: false,
+				statusBarPreferNonGenericParent: true,
+			},
+			runningEntry,
+			timekeep,
+			{
+				file,
+				type: TimekeepEntryItemType.FILE,
+			}
+		);
+
+		component.load();
+
+		const nameEl = component.containerEl.querySelector(".timekeep-status-item__name");
+		expect(nameEl).not.toBeNull();
+		expect(nameEl!.textContent.startsWith("Good block name / Part 2:")).toBeTruthy();
+	});
+
+	it("when statusBarPreferNonGenericParent is true if no non generic parent is found nothing should be used other than the entry name", () => {
+		const file = vault.addFile("nested/path/test.timekeep", "");
+
+		const runningEntry = {
+			id: 4,
+			name: "Part 2",
+			startTime: moment(start),
+			endTime: null,
+			subEntries: null,
+		};
+
+		const entry: TimeEntry = {
+			id: 1,
+			name: "Part 1",
+			startTime: null,
+			endTime: null,
+			subEntries: [
+				{
+					id: 2,
+					name: "Part 1",
+					startTime: null,
+					endTime: null,
+					subEntries: [
+						{
+							id: 3,
+							name: "Part 1",
+							startTime: moment(start),
+							endTime: moment(start),
+							subEntries: null,
+						},
+						runningEntry,
+					],
+				},
+			],
+		};
+
+		const timekeep: Timekeep = { entries: [entry] };
+
+		const component = new TimesheetStatusBarItem(
+			containerEl,
+			app,
+			registry,
+			{
+				...defaultSettings,
+				statusBarShowFolderPath: false,
+				statusBarPreferNonGenericParent: true,
+			},
+			runningEntry,
+			timekeep,
+			{
+				file,
+				type: TimekeepEntryItemType.FILE,
+			}
+		);
+
+		component.load();
+
+		const nameEl = component.containerEl.querySelector(".timekeep-status-item__name");
+		expect(nameEl).not.toBeNull();
+		expect(nameEl!.textContent.startsWith("Part 2:")).toBeTruthy();
+	});
+
+	it("when statusBarPreferNonGenericParent is true the path should not duplicate the entry name if its not generic", () => {
+		const file = vault.addFile("nested/path/test.timekeep", "");
+
+		const runningEntry = {
+			id: 4,
+			name: "Example Block",
+			startTime: moment(start),
+			endTime: null,
+			subEntries: null,
+		};
+
+		const entry: TimeEntry = runningEntry;
+		const timekeep: Timekeep = { entries: [entry] };
+
+		const component = new TimesheetStatusBarItem(
+			containerEl,
+			app,
+			registry,
+			{
+				...defaultSettings,
+				statusBarShowFolderPath: false,
+				statusBarPreferNonGenericParent: true,
+			},
+			runningEntry,
+			timekeep,
+			{
+				file,
+				type: TimekeepEntryItemType.FILE,
+			}
+		);
+
+		component.load();
+
+		const nameEl = component.containerEl.querySelector(".timekeep-status-item__name");
+		expect(nameEl).not.toBeNull();
+		expect(nameEl!.textContent.startsWith("Example Block / Example Block:")).toBeFalsy();
+	});
+
+	it("only the entry name should be used when statusBarPreferNonGenericParent is false", () => {
+		const file = vault.addFile("nested/path/test.timekeep", "");
+
+		const runningEntry = {
+			id: 4,
+			name: "Part 2",
+			startTime: moment(start),
+			endTime: null,
+			subEntries: null,
+		};
+
+		const entry: TimeEntry = {
+			id: 1,
+			name: "Good block name",
+			startTime: null,
+			endTime: null,
+			subEntries: [
+				{
+					id: 2,
+					name: "Part 1",
+					startTime: null,
+					endTime: null,
+					subEntries: [
+						{
+							id: 3,
+							name: "Part 1",
+							startTime: moment(start),
+							endTime: moment(start),
+							subEntries: null,
+						},
+						runningEntry,
+					],
+				},
+			],
+		};
+
+		const timekeep: Timekeep = { entries: [entry] };
+
+		const component = new TimesheetStatusBarItem(
+			containerEl,
+			app,
+			registry,
+			{
+				...defaultSettings,
+				statusBarShowFolderPath: false,
+				statusBarPreferNonGenericParent: false,
+			},
+			runningEntry,
+			timekeep,
+			{
+				file,
+				type: TimekeepEntryItemType.FILE,
+			}
+		);
+
+		component.load();
+
+		const nameEl = component.containerEl.querySelector(".timekeep-status-item__name");
+		expect(nameEl).not.toBeNull();
+		expect(nameEl!.textContent.startsWith("Part 2:")).toBeTruthy();
 	});
 });

--- a/src/components/TimesheetStatusBar/TimesheetStatusBarItem.ts
+++ b/src/components/TimesheetStatusBar/TimesheetStatusBarItem.ts
@@ -1,12 +1,14 @@
 import { App } from "obsidian";
 
 import { TimekeepSettings } from "@/settings";
+import { isGenericPartName } from "@/utils/name";
 
 import { DomComponent } from "@/components/DomComponent";
 import { createObsidianIcon } from "@/components/obsidianIcon";
 import { TimesheetEntryDuration } from "@/components/TimesheetEntryDuration";
 
-import { TimeEntry } from "@/timekeep/schema";
+import { getPathToEntry } from "@/timekeep/queries";
+import { TimeEntry, Timekeep } from "@/timekeep/schema";
 
 import {
 	TimekeepEntryItemType,
@@ -23,7 +25,8 @@ export class TimesheetStatusBarItem extends DomComponent {
 	registry: TimekeepRegistry;
 	/** The current timekeep settings */
 	settings: TimekeepSettings;
-
+	/** The full timekeep */
+	timekeep: Timekeep;
 	/** The reference to the item */
 	ref: TimekeepRegistryItemRef;
 
@@ -33,6 +36,7 @@ export class TimesheetStatusBarItem extends DomComponent {
 		registry: TimekeepRegistry,
 		settings: TimekeepSettings,
 		entry: TimeEntry,
+		timekeep: Timekeep,
 		ref: TimekeepRegistryItemRef
 	) {
 		super(containerEl);
@@ -41,6 +45,7 @@ export class TimesheetStatusBarItem extends DomComponent {
 		this.registry = registry;
 		this.settings = settings;
 		this.entry = entry;
+		this.timekeep = timekeep;
 		this.ref = ref;
 	}
 
@@ -64,7 +69,7 @@ export class TimesheetStatusBarItem extends DomComponent {
 
 		contentEl.createSpan({
 			cls: "timekeep-status-item__name",
-			text: this.getFolderPath() + entry.name + ":",
+			text: this.getFolderPath() + this.getEntryNearestName() + entry.name + ":",
 			title: this.getDisplayTitle(),
 		});
 
@@ -86,6 +91,21 @@ export class TimesheetStatusBarItem extends DomComponent {
 			}
 			/* v8 ignore stop -- @preserve */
 		}
+	}
+
+	getEntryNearestName() {
+		if (!this.settings.statusBarPreferNonGenericParent) return "";
+
+		const path = getPathToEntry(this.timekeep.entries, this.entry);
+		if (path.length < 2) return "";
+
+		for (let i = path.length - 2; i >= 0; i -= 1) {
+			const segment = path[i];
+			if (isGenericPartName(segment.name)) continue;
+			return `${segment.name} / `;
+		}
+
+		return "";
 	}
 
 	getFolderPath() {

--- a/src/service/autocomplete.ts
+++ b/src/service/autocomplete.ts
@@ -2,7 +2,7 @@ import { Component } from "obsidian";
 
 import { TimekeepSettings } from "@/settings";
 import { createStore, Store } from "@/store";
-import { isNumberText } from "@/utils/number";
+import { isGenericPartName } from "@/utils/name";
 
 import { TimekeepEntryItemType, TimekeepRegistry } from "./registry";
 
@@ -80,37 +80,10 @@ export class TimekeepAutocomplete extends Component {
 
 		const names = Array.from(namesSet)
 			//
-			.filter((name) => !TimekeepAutocomplete.isIgnoredName(name));
+			.filter((name) => !isGenericPartName(name));
 
 		names.sort();
 
 		this.names.setState(names);
-	}
-
-	/**
-	 * Checks if a name should be ignored from autocomplete
-	 *
-	 * @param name The name to check
-	 * @returns Whether the name should be ignored
-	 */
-	static isIgnoredName(name: string) {
-		if (name.length < 1) {
-			return true;
-		}
-
-		// Ignore "Part 1" "Part 2", "Block 1" ...etc
-		if (name.startsWith("Part") || name.startsWith("Block")) {
-			const parts = name.split(" ");
-			if (parts.length !== 2) {
-				return false;
-			}
-
-			const numericPart = parts[1];
-			if (isNumberText(numericPart)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/src/service/registry.test.ts
+++ b/src/service/registry.test.ts
@@ -944,6 +944,7 @@ describe("TimekeepRegistry", () => {
 						type: TimekeepEntryItemType.MARKDOWN,
 						position: { startLine: 0, endLine: 1 },
 					},
+					timekeep: { entries: [entry1] },
 				},
 				{
 					running: entry2,
@@ -951,6 +952,7 @@ describe("TimekeepRegistry", () => {
 						file: testFile3,
 						type: TimekeepEntryItemType.FILE,
 					},
+					timekeep: { entries: [entry2] },
 				},
 			] satisfies TimekeepRunningEntry[]);
 		});

--- a/src/service/registry.ts
+++ b/src/service/registry.ts
@@ -28,6 +28,7 @@ export type TimekeepRegistryEntry = TimekeepRegistryEntryFile | TimekeepRegistry
 export type TimekeepRunningEntry = {
 	running: TimeEntry;
 	ref: TimekeepRegistryItemRef;
+	timekeep: Timekeep;
 };
 
 /** Types of entries */
@@ -462,6 +463,7 @@ export class TimekeepRegistry extends Component {
 							type: entry.type,
 							file: entry.file,
 						},
+						timekeep,
 					});
 
 					break;
@@ -482,6 +484,7 @@ export class TimekeepRegistry extends Component {
 									endLine: timekeepWithPosition.endLine,
 								},
 							},
+							timekeep,
 						});
 					}
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -458,6 +458,21 @@ export class TimekeepSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(this.containerEl)
+			.setName("Show non generic entry parent name")
+			.setDesc(
+				'Whether to include the name of the nearest of the parent entry for generic "Part 1" style entries (i.e if "Part 1" is running within "Example Entry" it will be displayed as "Example Entry / Part 1: 3h 5min 30s").'
+			)
+			.addToggle((t) => {
+				t.setValue(settings.statusBarPreferNonGenericParent);
+				t.onChange((v) => {
+					this.settingsStore.setState((currentValue) => ({
+						...currentValue,
+						statusBarPreferNonGenericParent: v,
+					}));
+				});
+			});
+
+		new Setting(this.containerEl)
 			.setName("Open in new tab")
 			.setDesc('Whether to open the file in a new tab after clicking a status item").')
 			.addToggle((t) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,6 +74,7 @@ export interface TimekeepSettings {
 	registryConcurrencyLimit: number;
 
 	statusBarEnabled: boolean;
+	statusBarPreferNonGenericParent: boolean;
 	statusBarShowFolderPath: boolean;
 	statusBarItemOpenNewTab: boolean;
 
@@ -107,6 +108,7 @@ export const defaultSettings: TimekeepSettings = {
 
 	statusBarEnabled: true,
 	statusBarShowFolderPath: true,
+	statusBarPreferNonGenericParent: true,
 	statusBarItemOpenNewTab: false,
 
 	autocompleteEnabled: true,

--- a/src/utils/name.test.ts
+++ b/src/utils/name.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 
-import { NameSegmentType, parseNameSegments } from "./name";
+import { isGenericPartName, NameSegmentType, parseNameSegments } from "./name";
 
 describe("parseNameSegments", () => {
 	it("should parse plain text without modification", () => {
@@ -138,5 +138,25 @@ describe("parseNameSegments", () => {
 		const input = "[Text]()";
 		const result = parseNameSegments(input);
 		expect(result).toEqual([{ type: NameSegmentType.Text, text: "[Text]()" }]);
+	});
+});
+
+describe("isGenericPartName", () => {
+	it.for(["Block 1", "Part 1", "Part 2", "Block 2", "Block 999999999", "Part 9999999999"])(
+		"'%s' should be a detected as a generic part name",
+		(name) => {
+			expect(isGenericPartName(name)).toBeTruthy();
+		}
+	);
+
+	it.for([
+		"Custom Block",
+		"Custom Part",
+		"Part with a number 1",
+		"Some random text thats definitely not generic",
+		"Part 1___1",
+		"Block_1",
+	])("'%s' should not be a detected as a generic part name", (name) => {
+		expect(isGenericPartName(name)).toBeFalsy();
 	});
 });

--- a/src/utils/name.ts
+++ b/src/utils/name.ts
@@ -1,3 +1,5 @@
+import { isNumberText } from "@/utils/number";
+
 export enum NameSegmentType {
 	Text,
 	Link,
@@ -60,4 +62,32 @@ export function parseNameSegments(input: string): NameSegment[] {
 	}
 
 	return segments;
+}
+
+/**
+ * Checks if a name is a generic "Part 1", "Block 1" style
+ * naming convention
+ *
+ * @param name The name
+ * @returns Whether it matches the naming convention
+ */
+export function isGenericPartName(name: string): boolean {
+	if (name.length < 1) {
+		return true;
+	}
+
+	// Ignore "Part 1" "Part 2", "Block 1" ...etc
+	if (name.startsWith("Part") || name.startsWith("Block")) {
+		const parts = name.split(" ");
+		if (parts.length !== 2) {
+			return false;
+		}
+
+		const numericPart = parts[1];
+		if (isNumberText(numericPart)) {
+			return true;
+		}
+	}
+
+	return false;
 }


### PR DESCRIPTION
## Description

Provides a new option "Show non generic entry parent name" for "Status Bar" to allow including a new segment in the status bar items for the case when you are working on "Part {x}"  within task "Example Task", instead of showing just "Part {x}" in the status bar, this option will instead include the nearest non generic parent entry name causing the name to be displayed as "Example Task / Part {x}: " instead of "Part {x}: " to give more meaningful context. 

## Changes

- The registry running logic now also provides a reference to the timekeep itself and not just the running entry
- Updated registry tests to include the new timekeep reference 
- Added new setting statusBarPreferNonGenericParent shown as "Show non generic entry parent name" in the UI
- Moved isIgnoredName from the autocomplete.ts module over to name.ts and renamed it to isGenericPartName
- Added tests for isGenericPartName
- Added new getEntryNearestName logic to TimesheetStatusBarItem.ts to add the entry path 
- Added new tests for TimesheetStatusBarItem for the new entry naming rules

## Related Issues

- Closes #92 

## Screenshots

<img width="1799" height="1298" alt="image" src="https://github.com/user-attachments/assets/ae8ae744-7fd5-4a76-a759-c8b58a7af18e" />

<img width="375" height="86" alt="image" src="https://github.com/user-attachments/assets/43a03e4b-baa5-4ed9-b327-e9fb19489527" />


<img width="2297" height="1825" alt="image" src="https://github.com/user-attachments/assets/7fd09325-e81a-4969-a720-68b7b5feed70" />
