### PR TITLE
feat: use browser built in datetime-local pickers for start and end time with additional validation rules

### DIFF
--- a/src/components/TimesheetRow/TimesheetRowContentEditing.test.ts
+++ b/src/components/TimesheetRow/TimesheetRowContentEditing.test.ts
@@ -333,7 +333,7 @@ describe("TimesheetRowContentEditing", () => {
 		expect(timekeep.getState()).toEqual({ entries: [] });
 	});
 
-	it("editing a group entry should hide the start and end time inputs", () => {
+	it("trying to save an entry with invalid times should be stopped and produce validation errors", () => {
 		const start = moment();
 		const entry: TimeEntry = {
 			id: 1,
@@ -364,6 +364,13 @@ describe("TimesheetRowContentEditing", () => {
 		expect(startTime).not.toBeNull();
 		expect(endTime).not.toBeNull();
 
+		const startTimeSetCustomValidity = vi.spyOn(
+			startTime as HTMLInputElement,
+			"setCustomValidity"
+		);
+		const endTimeSetCustomValidity = vi.spyOn(endTime as HTMLInputElement, "setCustomValidity");
+
+		// Set random dates to ensure the date is not persisted for group edits
 		(startTime as HTMLInputElement).value = "Test";
 		(endTime as HTMLInputElement).value = "Test";
 
@@ -374,8 +381,74 @@ describe("TimesheetRowContentEditing", () => {
 		);
 
 		expect(onSubmit).toHaveBeenCalledOnce();
-		expect(onFinishEditing).toHaveBeenCalledOnce();
-		expect(setState).toHaveBeenCalledOnce();
+		expect(onFinishEditing).not.toHaveBeenCalled();
+		expect(setState).not.toHaveBeenCalledOnce();
+
+		expect(startTimeSetCustomValidity).toHaveBeenCalledWith("Invalid start time provided");
+		expect(endTimeSetCustomValidity).toHaveBeenCalledWith("Invalid end time provided");
+
+		// Entry should not have changed if the input values were not valid timestamps
+		expect(timekeep.getState()).toEqual({ entries: [entry] });
+	});
+
+	it("trying to save an entry with a start time after the end time should be stopped and produce validation errors", () => {
+		const start = moment();
+		const entry: TimeEntry = {
+			id: 1,
+			name: "Test",
+			startTime: moment(start),
+			endTime: moment(start),
+			subEntries: null,
+		};
+
+		timekeep.setState({ entries: [entry] });
+
+		const setState = vi.spyOn(timekeep, "setState");
+
+		component = new TimesheetRowContentEditing(
+			containerEl,
+			app,
+			timekeep,
+			settings,
+			entry,
+			onFinishEditing
+		);
+		const onSubmit = vi.spyOn(component, "onSubmit");
+		component.load();
+
+		const startTime = containerEl.querySelector('.timekeep-input[name="start-time"]');
+		const endTime = containerEl.querySelector('.timekeep-input[name="end-time"]');
+
+		expect(startTime).not.toBeNull();
+		expect(endTime).not.toBeNull();
+
+		const dateInputFormat = "YYYY-MM-DDTHH:mm:ss";
+
+		const newStartTime = moment();
+		const newEndTime = moment(newStartTime).subtract(5, "d");
+
+		const startTimeSetCustomValidity = vi.spyOn(
+			startTime as HTMLInputElement,
+			"setCustomValidity"
+		);
+
+		// Set random dates to ensure the date is not persisted for group edits
+		(startTime as HTMLInputElement).value = newStartTime.format(dateInputFormat);
+		(endTime as HTMLInputElement).value = newEndTime.format(dateInputFormat);
+
+		const form = containerEl.querySelector("form.timekeep-editing");
+		expect(form).not.toBeNull();
+		(form as HTMLFormElement).dispatchEvent(
+			new SubmitEvent("submit", { bubbles: true, cancelable: true })
+		);
+
+		expect(onSubmit).toHaveBeenCalledOnce();
+		expect(onFinishEditing).not.toHaveBeenCalled();
+		expect(setState).not.toHaveBeenCalledOnce();
+
+		expect(startTimeSetCustomValidity).toHaveBeenCalledWith(
+			"Start time cannot be after the end time"
+		);
 
 		// Entry should not have changed if the input values were not valid timestamps
 		expect(timekeep.getState()).toEqual({ entries: [entry] });

--- a/src/components/TimesheetRow/TimesheetRowContentEditing.ts
+++ b/src/components/TimesheetRow/TimesheetRowContentEditing.ts
@@ -226,17 +226,17 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 		const startTimeValue = this.#startTimeInputEl.value;
 		const endTimeValue = this.#endTimeInputEl.value;
 
-		let valid = true;
-
 		let startTime: Moment | null = null;
 		let endTime: Moment | null = null;
+
+		let startTimeError: string | null = null;
+		let endTimeError: string | null = null;
 
 		if (entry.startTime !== null) {
 			startTime = parseDateInputValue(startTimeValue);
 			if (!startTime.isValid()) {
 				startTime = null;
-				startTimeEl.setCustomValidity("Invalid start time provided");
-				valid = false;
+				startTimeError = "Invalid start time provided";
 			}
 		}
 
@@ -244,20 +244,18 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 			endTime = parseDateInputValue(endTimeValue);
 			if (!endTime.isValid()) {
 				endTime = null;
-				endTimeEl.setCustomValidity("Invalid end time provided");
-				valid = false;
+				endTimeError = "Invalid end time provided";
 			}
 		}
 
 		if (startTime !== null && endTime !== null && startTime.isAfter(endTime)) {
-			startTimeEl.setCustomValidity("Start time cannot be after the end time");
-			valid = false;
+			startTimeError = "Start time cannot be after the end time";
 		}
 
-		if (!valid) {
-			startTimeEl.reportValidity();
-			endTimeEl.reportValidity();
-		}
+		startTimeEl.setCustomValidity(startTimeError ?? "");
+		endTimeEl.setCustomValidity(endTimeError ?? "");
+
+		const valid = startTimeError === null && endTimeError === null;
 
 		return { valid, startTime, endTime };
 	}

--- a/src/components/TimesheetRow/TimesheetRowContentEditing.ts
+++ b/src/components/TimesheetRow/TimesheetRowContentEditing.ts
@@ -1,10 +1,11 @@
+import type { Moment } from "moment";
 import type { App } from "obsidian";
 
 import type { TimekeepSettings } from "@/settings";
 import type { Store } from "@/store";
 
 import { assert } from "@/utils/assert";
-import { formatEditableTimestamp, parseEditableTimestamp } from "@/utils/time";
+import { parseDateInputValue } from "@/utils/time";
 
 import { createObsidianIcon } from "@/components/obsidianIcon";
 import { ReplaceableComponent } from "@/components/ReplaceableComponent";
@@ -86,16 +87,20 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 		nameInputEl.name = "name";
 		this.#nameInputEl = nameInputEl;
 
+		const onValidateDates = this.onValidateDates.bind(this);
+
 		const startTimeLabelEl = formEl.createEl("label", {
 			text: "Start Time",
 		});
 		this.#startTimeLabelEl = startTimeLabelEl;
 		const startTimeInputEl = startTimeLabelEl.createEl("input", {
 			cls: "timekeep-input",
-			type: "text",
+			type: "datetime-local",
 		});
 		startTimeInputEl.name = "start-time";
+		startTimeInputEl.step = "0.001";
 		this.#startTimeInputEl = startTimeInputEl;
+		this.registerDomEvent(startTimeInputEl, "input", onValidateDates);
 
 		const endTimeLabelEl = formEl.createEl("label", {
 			cls: "timekeep-input-label",
@@ -104,10 +109,12 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 		this.#endTimeLabelEl = endTimeLabelEl;
 		const endTimeInputEl = endTimeLabelEl.createEl("input", {
 			cls: "timekeep-input",
-			type: "text",
+			type: "datetime-local",
 		});
 		endTimeInputEl.name = "end-time";
+		endTimeInputEl.step = "0.001";
 		this.#endTimeInputEl = endTimeInputEl;
+		this.registerDomEvent(endTimeInputEl, "input", onValidateDates);
 
 		const actionsEl = formEl.createDiv({
 			cls: "timekeep-editing-actions",
@@ -162,20 +169,17 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 			"Elements expected to be defined"
 		);
 
-		const settings = this.settings.getState();
 		const entry = this.entry;
 
 		this.#nameInputEl.value = entry.name;
 
+		const inputFormat = "YYYY-MM-DDTHH:mm:ss";
+
 		this.#startTimeLabelEl.hidden = entry.startTime === null;
-		this.#startTimeInputEl.value = entry.startTime
-			? formatEditableTimestamp(entry.startTime, settings)
-			: "";
+		this.#startTimeInputEl.value = entry.startTime ? entry.startTime.format(inputFormat) : "";
 
 		this.#endTimeLabelEl.hidden = entry.endTime === null;
-		this.#endTimeInputEl.value = entry.endTime
-			? formatEditableTimestamp(entry.endTime, settings)
-			: "";
+		this.#endTimeInputEl.value = entry.endTime ? entry.endTime.format(inputFormat) : "";
 	}
 
 	onConfirmDelete() {
@@ -200,38 +204,84 @@ export class TimesheetRowContentEditing extends ReplaceableComponent {
 		}));
 	}
 
-	onSubmit(event: Event) {
+	/**
+	 * Validates that the start and end dates are valid if they are
+	 * present, also applies the validation error messages
+	 *
+	 * @returns Whether the validation succeeded
+	 */
+	onValidateDates() {
 		assert(
 			this.#nameInputEl && this.#startTimeInputEl && this.#endTimeInputEl,
 			"Expected inputs to be defined"
 		);
 
+		const startTimeEl = this.#startTimeInputEl;
+		const endTimeEl = this.#endTimeInputEl;
+
+		const entry = this.entry;
+
+		if (entry.subEntries !== null) return { valid: true, startTime: null, endTime: null };
+
+		const startTimeValue = this.#startTimeInputEl.value;
+		const endTimeValue = this.#endTimeInputEl.value;
+
+		let valid = true;
+
+		let startTime: Moment | null = null;
+		let endTime: Moment | null = null;
+
+		if (entry.startTime !== null) {
+			startTime = parseDateInputValue(startTimeValue);
+			if (!startTime.isValid()) {
+				startTime = null;
+				startTimeEl.setCustomValidity("Invalid start time provided");
+				valid = false;
+			}
+		}
+
+		if (entry.endTime !== null) {
+			endTime = parseDateInputValue(endTimeValue);
+			if (!endTime.isValid()) {
+				endTime = null;
+				endTimeEl.setCustomValidity("Invalid end time provided");
+				valid = false;
+			}
+		}
+
+		if (startTime !== null && endTime !== null && startTime.isAfter(endTime)) {
+			startTimeEl.setCustomValidity("Start time cannot be after the end time");
+			valid = false;
+		}
+
+		if (!valid) {
+			startTimeEl.reportValidity();
+			endTimeEl.reportValidity();
+		}
+
+		return { valid, startTime, endTime };
+	}
+
+	async onSubmit(event: Event) {
+		assert(this.#nameInputEl, "Expected inputs to be defined");
+
 		event.preventDefault();
 		event.stopPropagation();
 
-		const name = this.#nameInputEl.value;
-		const startTime = this.#startTimeInputEl.value;
-		const endTime = this.#endTimeInputEl.value;
+		const { valid, startTime, endTime } = this.onValidateDates();
+		if (!valid) return;
 
-		const settings = this.settings.getState();
+		const name = this.#nameInputEl.value;
 		const entry = this.entry;
 
 		const newEntry = { ...entry, name };
-
-		// Update the start and end times for non groups
 		if (newEntry.subEntries === null) {
-			if (entry.startTime !== null) {
-				const startTimeValue = parseEditableTimestamp(startTime, settings);
-				if (startTimeValue.isValid()) {
-					newEntry.startTime = startTimeValue;
-				}
+			if (startTime !== null) {
+				newEntry.startTime = startTime;
 			}
 
-			if (entry.endTime !== null) {
-				const endTimeValue = parseEditableTimestamp(endTime, settings);
-				if (endTimeValue.isValid()) {
-					newEntry.endTime = endTimeValue;
-				}
+			if (endTime !== null) {
+				newEntry.endTime = endTime;
 			}
 		}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,7 +47,6 @@ export enum UnstartedOrder {
 export interface TimekeepSettings {
 	csvDelimiter: string;
 	csvTitle: boolean;
-	editableTimestampFormat: string;
 	limitTableSize: boolean;
 	pdfFootnote: string;
 	pdfTitle: string;
@@ -91,7 +90,6 @@ export const defaultSettings: TimekeepSettings = {
 	pdfFontFamily: FontFamily.ROBOTO,
 	pdfMobileExportsFolder: "TimekeepExports",
 	timestampFormat: "YY-MM-DD HH:mm:ss",
-	editableTimestampFormat: "YYYY-MM-DD HH:mm:ss",
 	csvTitle: true,
 	csvDelimiter: ",",
 	limitTableSize: true,

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -11,8 +11,6 @@ import {
 	formatDurationLong,
 	formatDurationShort,
 	formatDurationDecimal,
-	parseEditableTimestamp,
-	formatEditableTimestamp,
 } from "./time";
 
 describe("formatTimestamp", () => {
@@ -26,34 +24,6 @@ describe("formatTimestamp", () => {
 		const output = formatTimestamp(input, settings);
 
 		expect(output).toBe(expected);
-	});
-});
-
-describe("formatEditableTimestamp", () => {
-	it("should format editable time", () => {
-		const input = moment("2024-03-31T02:34:45.413Z").utc();
-		const expected = "2024-03-31 02:34:45";
-
-		const settings: TimekeepSettings = defaultSettings;
-		settings.editableTimestampFormat = "YYYY-MM-DD HH:mm:ss";
-
-		const output = formatEditableTimestamp(input, settings);
-
-		expect(output).toBe(expected);
-	});
-});
-
-describe("parseEditableTimestamp", () => {
-	it("should parse editable time", () => {
-		const input = "2024-03-31 02:34:45";
-		const expected = moment("2024-03-31 02:34:45", "YYYY-MM-DD HH:mm:ss");
-
-		const settings: TimekeepSettings = defaultSettings;
-		settings.editableTimestampFormat = "YYYY-MM-DD HH:mm:ss";
-
-		const output = parseEditableTimestamp(input, settings).utc();
-
-		expect(output.toDate()).toStrictEqual(expected.toDate());
 	});
 });
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -36,6 +36,23 @@ export function parseEditableTimestamp(formatted: string, settings: TimekeepSett
 	return moment(formatted, settings.editableTimestampFormat, true);
 }
 
+/** Formats the HTML <input/> with type datetime-local may use */
+const BROWSER_INPUT_DATETIME_FORMATS = [
+	"YYYY-MM-DDTHH:mm:ss.SSS",
+	"YYYY-MM-DDTHH:mm:ss",
+	"YYYY-MM-DDTHH:mm",
+];
+
+/**
+ * Parses a date from a HTML <input/> datetime-local value
+ *
+ * @param value The input value
+ * @returns The parsed date
+ */
+export function parseDateInputValue(value: string): Moment {
+	return moment(value, BROWSER_INPUT_DATETIME_FORMATS, true);
+}
+
 /**
  * Formats a duration using the provided duration format
  *

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -13,29 +13,6 @@ export function formatTimestamp(timestamp: Moment, settings: TimekeepSettings): 
 	return timestamp.format(settings.timestampFormat);
 }
 
-/**
- * Formats the provided timestamp in the way its expected to be
- * edited by the user
- *
- * @param timestamp The timestamp to format
- * @param settings The timekeep settings
- * @returns The formatted timestamp
- */
-export function formatEditableTimestamp(timestamp: Moment, settings: TimekeepSettings): string {
-	return timestamp.format(settings.editableTimestampFormat);
-}
-
-/**
- * Converts the user edited format back into a timestamp
- *
- * @param formatted The user edited formatted timestamp
- * @param settings The timekeep settings
- * @returns The timestamp
- */
-export function parseEditableTimestamp(formatted: string, settings: TimekeepSettings): Moment {
-	return moment(formatted, settings.editableTimestampFormat, true);
-}
-
 /** Formats the HTML <input/> with type datetime-local may use */
 const BROWSER_INPUT_DATETIME_FORMATS = [
 	"YYYY-MM-DDTHH:mm:ss.SSS",


### PR DESCRIPTION
## Description

Replaces the start and end time inputs with native datetime-local inputs and improves the validation rules to prevent saving a start time thats after the end time

## Changes

- Replaced the inputs for editing start and end times with native datetime-local inputs
- Validation errors applied to the start and end inputs
- Validation error for the start time being after the end time
- Tests for the validation errors
- Removes legacy editableTimestampFormat setting that wasn't connected to the UI

## Related Issues

- Closes #80 

## Screenshots

<img width="1246" height="488" alt="image" src="https://github.com/user-attachments/assets/25ff2a38-c174-4084-bfae-cda672a5d797" />

<img width="1246" height="488" alt="image" src="https://github.com/user-attachments/assets/dd018bea-c23a-42a8-b5a9-59b39f3246d1" />

<img width="1237" height="508" alt="image" src="https://github.com/user-attachments/assets/29e0bb84-1c30-491a-80a7-cc540fa36c53" />
